### PR TITLE
Updates dtype to np.int64

### DIFF
--- a/torchstat2/model_hook.py
+++ b/torchstat2/model_hook.py
@@ -114,7 +114,7 @@ class ModelHook(object):
             for name, p in module._parameters.items():
                 parameter_quantity += (0 if p is None else torch.numel(p.data))
             module.parameter_quantity = torch.from_numpy(
-                np.array([parameter_quantity], dtype=np.long))
+                np.array([parameter_quantity], dtype=np.int64))
 
             # Calculate inference memory more accurately
             # Include both output tensor size and parameter memory


### PR DESCRIPTION
Changes the dtype of the parameter quantity array from np.long to np.int64 for better compatibility and consistency, as np.long is deprecated since NumPy 1.20